### PR TITLE
Disable "extended" flag passed to express.urlencoded

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ const app = express();
 app.set('view engine', 'ejs');
 
 app.use(express.static(path.join(__dirname, 'public')));
-app.use(express.urlencoded({ extended: true }));
+app.use(express.urlencoded({ extended: false }));
 
 app.get('/', async (req, res) => {
     try {


### PR DESCRIPTION
This flag allows for `a[b]=c` bodies, which would result in `{ a: { b: "c" } }`.
Passing this to the endpoint `/update-settings` as such:
![image](https://github.com/user-attachments/assets/6981e8bd-22c9-419b-b226-3c622f9793bd)
leads to "corruption" of the configuration file
![image](https://github.com/user-attachments/assets/439398c3-8050-42e1-908c-1368815bf764)
